### PR TITLE
update 0.72 file in releases folder.

### DIFF
--- a/src/components/common/UsefulLinks.js
+++ b/src/components/common/UsefulLinks.js
@@ -64,6 +64,10 @@ class UsefulLinks extends Component {
     return (
       <>
         {versions.map(({ usefulContent, version }, key) => {
+          if (!usefulContent) {
+            return null
+          }
+      
           const changelog = this.getChangelog({ version })
 
           const links = [...usefulContent.links, changelog]


### PR DESCRIPTION
# Summary

Preventing crashes when version files contain empty usefulContent. 

## Test Plan
1. select current react-native versions below 0.68.6.
2. select upgrade 0.72.0 or higher version.
3. click 'Show me how to upgrade!' button.
4. web is crushed.
